### PR TITLE
Update LegrandSwitch.groovy to Handle Switches with null States

### DIFF
--- a/LegrandSwitch.groovy
+++ b/LegrandSwitch.groovy
@@ -55,10 +55,11 @@ def propertiesChanged (propList) {
 
     propList.each { key, val ->
         if (key == "Power") {
-            if (val.toBoolean() == true && device.currentState("switch")?.value == "off")
+            if (val.toBoolean() == true && (device.currentState("switch")?.value == "off" || device.currentState("switch")?.value == null)) {
                 sendEvent(name: "switch", value: "on")
-            else if (val.toBoolean() == false && device.currentState("switch")?.value == "on")
+            } else if (val.toBoolean() == false && (device.currentState("switch")?.value == "on" || device.currentState("switch")?.value == null)) {
                 sendEvent(name: "switch", value: "off")
+            }                
         } else if (key == "PowerLevel") {
             if (val.toInteger() != device.currentState("level")?.value) {
                 sendEvent(name: "level", value: val.toInteger())


### PR DESCRIPTION
When a Legrand switch is initially imported into SmartThings for the first time, it may be in a "null" state. Prior to this edit, there was no way for a null-valued switch to trigger a sendEvent. Since a sendEvent is the only way to change the switch's state from "null" to "on" or "off," this inability to trigger a sendEvent left the null-valued switch with a "null" state in perpetuity. And while in a "null" state, the switch's status cannot be accurately reflected in SmartThings.