### PR TITLE
Update LegrandConnect.groovy to Accept Zone Property Changes When ZID…

### DIFF
--- a/LegrandConnect.groovy
+++ b/LegrandConnect.groovy
@@ -262,7 +262,7 @@ def postNotifyCallback() {
             }
             break
         case "ZonePropertiesChanged":
-            if (!reqJSON.ZID)
+            if (!reqJSON.ZID && reqJSON.ZID != 0)
                 log.error ("ZID not found in POST request. Request JSON: ${reqJSON}")
             else {
                 def d = getChildDevice(createDNI(reqJSON.ZID))


### PR DESCRIPTION
… = 0

Prior to this change, a status report with ZID = 0 would log an error instead of grabbing the status of the light with ZID = 0. This was due to an if statement searching for any negated reqJSON.ZID value (considering a value of 0 as a negation). This resulted in an undesired if statement being entered when a status was received from a light with ZID = 0.